### PR TITLE
Restructure the setup config load order

### DIFF
--- a/lib/ceedling.rb
+++ b/lib/ceedling.rb
@@ -92,8 +92,8 @@ module Ceedling
 
     # Register the plugin with Ceedling
     require 'ceedling/defaults'
-    DEFAULT_CEEDLING_CONFIG[:plugins][:enabled]    << name
-    DEFAULT_CEEDLING_CONFIG[:plugins][:load_paths] << gem_dir
+    CEEDLING_CONFIG_INTERNAL[:plugins][:enabled]    << name
+    CEEDLING_CONFIG_INTERNAL[:plugins][:load_paths] << gem_dir
   end
 end
 

--- a/lib/ceedling/defaults.rb
+++ b/lib/ceedling/defaults.rb
@@ -325,12 +325,6 @@ DEFAULT_CEEDLING_CONFIG = {
       :include => [],
     },
 
-    # unlike other top-level entries, environment's value is an array to preserve order
-    :environment => [
-      # when evaluated, this provides wider text field for rake task comments
-      {:rake_columns => '120'},
-    ],
-
     :defines => {
       :test => [],
       :test_preprocess => [],
@@ -365,18 +359,15 @@ DEFAULT_CEEDLING_CONFIG = {
     },
 
     :unity => {
-      :vendor_path => CEEDLING_VENDOR,
       :defines => []
     },
 
     :cmock => {
-      :vendor_path => CEEDLING_VENDOR,
       :defines => [],
       :includes => []
     },
 
     :cexception => {
-      :vendor_path => CEEDLING_VENDOR,
       :defines => []
     },
 
@@ -404,6 +395,28 @@ DEFAULT_CEEDLING_CONFIG = {
     :release_linker    => { :arguments => [] },
     :release_assembler => { :arguments => [] },
     :release_dependencies_generator => { :arguments => [] },
+
+  }.freeze
+
+CEEDLING_CONFIG_INTERNAL = {
+
+    # unlike other top-level entries, environment's value is an array to preserve order
+    :environment => [
+      # when evaluated, this provides wider text field for rake task comments
+      {:rake_columns => '120'},
+    ],
+
+    :unity => {
+      :vendor_path => CEEDLING_VENDOR
+    },
+
+    :cmock => {
+      :vendor_path => CEEDLING_VENDOR
+    },
+
+    :cexception => {
+      :vendor_path => CEEDLING_VENDOR
+    },
 
     :plugins => {
       :load_paths => CEEDLING_PLUGINS,

--- a/lib/ceedling/setupinator.rb
+++ b/lib/ceedling/setupinator.rb
@@ -16,14 +16,16 @@ class Setupinator
 
   def do_setup(config_hash)
     @config_hash = config_hash
+    defaults_hash = {}
 
     # load up all the constants and accessors our rake files, objects, & external scripts will need;
     # note: configurator modifies the cmock section of the hash with a couple defaults to tie 
     #       project together - the modified hash is used to build cmock object
-    @ceedling[:configurator].populate_defaults( config_hash )
-    @ceedling[:configurator].populate_unity_defaults( config_hash )
-    @ceedling[:configurator].populate_cmock_defaults( config_hash )
-    @ceedling[:configurator].find_and_merge_plugins( config_hash )
+    @ceedling[:configurator].merge_ceedling_config( config_hash, defaults_hash )
+    @ceedling[:configurator].merge_cmock_config( config_hash, defaults_hash )
+    @ceedling[:configurator].find_and_merge_plugins( config_hash, defaults_hash )
+    @ceedling[:configurator].populate_config_with_defaults( config_hash, defaults_hash )
+    @ceedling[:configurator].populate_runner_config( config_hash )
     @ceedling[:configurator].merge_imports( config_hash )
     @ceedling[:configurator].eval_environment_variables( config_hash )
     @ceedling[:configurator].tools_setup( config_hash )

--- a/spec/ceedling_spec.rb
+++ b/spec/ceedling_spec.rb
@@ -82,8 +82,8 @@ describe 'Ceedling' do
 
     it 'should load the project with the specified plugins enabled' do
       # create test state/variables
-      DEFAULT_CEEDLING_CONFIG[:plugins][:enabled].clear()
-      DEFAULT_CEEDLING_CONFIG[:plugins][:load_paths].clear()
+      CEEDLING_CONFIG_INTERNAL[:plugins][:enabled].clear()
+      CEEDLING_CONFIG_INTERNAL[:plugins][:load_paths].clear()
       spec_double = double('spec-double')
       rakefile_path = File.join(File.dirname(__FILE__), '..').gsub('spec','lib')
       rakefile_path = File.join( rakefile_path, 'lib', 'ceedling', 'rakefile.rb' )
@@ -102,8 +102,8 @@ describe 'Ceedling' do
     it 'should set the project root if the root key is provided' do
       # create test state/variables
       Object.send(:remove_const, :PROJECT_ROOT)
-      DEFAULT_CEEDLING_CONFIG[:plugins][:enabled].clear()
-      DEFAULT_CEEDLING_CONFIG[:plugins][:load_paths].clear()
+      CEEDLING_CONFIG_INTERNAL[:plugins][:enabled].clear()
+      CEEDLING_CONFIG_INTERNAL[:plugins][:load_paths].clear()
       rakefile_path = File.join(File.dirname(__FILE__), '..').gsub('spec','lib')
       rakefile_path = File.join( rakefile_path, 'lib', 'ceedling', 'rakefile.rb' )
       # mocks/stubs/expected calls
@@ -120,8 +120,8 @@ describe 'Ceedling' do
   context 'register_plugin' do
     it 'should register a plugin' do
       # create test state/variables
-      DEFAULT_CEEDLING_CONFIG[:plugins][:enabled].clear()
-      DEFAULT_CEEDLING_CONFIG[:plugins][:load_paths].clear()
+      CEEDLING_CONFIG_INTERNAL[:plugins][:enabled].clear()
+      CEEDLING_CONFIG_INTERNAL[:plugins][:load_paths].clear()
       spec_double = double('spec-double')
       # mocks/stubs/expected calls
       expect(Gem::Specification).to receive(:find_by_name).with('ceedling-foo').and_return(spec_double)
@@ -130,14 +130,14 @@ describe 'Ceedling' do
       # execute method
       Ceedling.register_plugin('foo')
       # validate results
-      expect(DEFAULT_CEEDLING_CONFIG[:plugins][:enabled]).to eq ["foo"]
-      expect(DEFAULT_CEEDLING_CONFIG[:plugins][:load_paths]).to eq(["dummy/path"])
+      expect(CEEDLING_CONFIG_INTERNAL[:plugins][:enabled]).to eq ["foo"]
+      expect(CEEDLING_CONFIG_INTERNAL[:plugins][:load_paths]).to eq(["dummy/path"])
     end
 
     it 'should register a plugin with an alternative prefix' do
       # create test state/variables
-      DEFAULT_CEEDLING_CONFIG[:plugins][:enabled].clear()
-      DEFAULT_CEEDLING_CONFIG[:plugins][:load_paths].clear()
+      CEEDLING_CONFIG_INTERNAL[:plugins][:enabled].clear()
+      CEEDLING_CONFIG_INTERNAL[:plugins][:load_paths].clear()
       spec_double = double('spec-double')
       # mocks/stubs/expected calls
       expect(Gem::Specification).to receive(:find_by_name).with('prefix-foo').and_return(spec_double)
@@ -146,8 +146,8 @@ describe 'Ceedling' do
       # execute method
       Ceedling.register_plugin('foo','prefix-')
       # validate results
-      expect(DEFAULT_CEEDLING_CONFIG[:plugins][:enabled]).to eq(["foo"])
-      expect(DEFAULT_CEEDLING_CONFIG[:plugins][:load_paths]).to eq(["dummy/path"])
+      expect(CEEDLING_CONFIG_INTERNAL[:plugins][:enabled]).to eq(["foo"])
+      expect(CEEDLING_CONFIG_INTERNAL[:plugins][:load_paths]).to eq(["dummy/path"])
     end
   end
 end


### PR DESCRIPTION
Change the structure to merge both the default configs and the user-defined configs separately. Then combine the two sets of merged configs. In the previous order structure, certain default settings had a higher priority than plugin settings. With these changes, all user-defined configs will now have higher priority than any default setting.